### PR TITLE
docs: add Canadian science internship resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,10 +381,12 @@ A curated list of opportunities in biology/medicine/bioinformatics, including ac
 
 ### RA/Internship
 **Research assistant and internship opportunities**
-<!-- <details>
+<details>
 <summary>🌎 North America</summary>
 
-</details> -->
+- 🇨🇦 [Canadian science internships, co-ops, and entry-level roles — Hanzilla Jobs](https://jobs.hanzilla.co/sciences/)
+
+</details>
 
 <details>
 <summary>🌍 Europe</summary>


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs' Canada science landing page to the RA/Internship North America section.
- The page tracks Canadian student/recent-grad science opportunities, including internships, co-ops, lab/field roles, and entry-level roles.

## Why
This repo already includes Canada-specific bio/science opportunities in other sections. Hanzilla is a free, daily-updated Canada-focused student/recent-grad jobs board, so the science page can help students find active Canadian internship and early-career postings.
